### PR TITLE
Adjusted Wind audition procedure

### DIFF
--- a/app/[locale]/join/de.mdx
+++ b/app/[locale]/join/de.mdx
@@ -27,7 +27,7 @@ Wir freuen uns darauf, von dir zu hören!
 ### Für Streicher
 Das Vorspiel findet in der Form eines Quartettabends statt. Zusammen mit den Stimmführern des Orchesters spielst du Auszüge aus einem früheren Programm. So kannst du ein Gefühl für das Zusammenspiel im Orchester bekommen und uns kennenlernen.
 
-**Das Streicher-Vorspiel für das Frühlingssemester 2026 findet am 16. Februar statt**
+**Das Streicher-Vorspiel für das Frühlingssemester 2026 findet am 17. Februar statt**
 
 ### Für Bläser
 Für das Bläservorspiel senden wir dir einen Ausschnitt (ca. 2-3 Minuten) eines Stücks aus unserem aktuellen Programm. 

--- a/app/[locale]/join/en.mdx
+++ b/app/[locale]/join/en.mdx
@@ -27,7 +27,7 @@ We look forward to hearing from you!
 ### For Strings
 Auditions typically take the form of a quartet evening. Together with the section leaders of the orchestra, you'll play excerpts from a previous program. This allows you to get a feel for playing together in the orchestra and get to know us.
 
-**The string auditions for spring 2026 will be held on February 16th.**
+**The string auditions for spring 2026 will be held on February 17th.**
 
 ### For Wind and Brass
 For the wind audition, we will send you an excerpt (approx. 2–3 minutes) from a piece in our current program. In addition, we ask you to prepare a piece of your choice of similar length and perform it for us.


### PR DESCRIPTION
Corrected the procedure for wind auditions (in German), updated various phrases to use lowercase 'du' and corrected the date for the string quartet audition.