### PR TITLE
Fix navbar height jump on homepage and small cleanups

### DIFF
--- a/app/[locale]/concerts/[slug]/page.tsx
+++ b/app/[locale]/concerts/[slug]/page.tsx
@@ -1,6 +1,5 @@
 // app/[locale]/concerts/[slug]/page.tsx
 import { notFound } from 'next/navigation';
-import Image from 'next/image';
 import { getAllConcertSlugs, getConcertMetadata, getConcertGalleryImages } from '@/lib/concerts';
 import { Link } from '@/routing';
 import { getTranslations } from 'next-intl/server';

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,6 +1,5 @@
 // components/Footer.tsx
 import { useTranslations } from 'next-intl';
-import Image from 'next/image';
 
 export default function Footer() {
   const t = useTranslations('Footer');
@@ -9,22 +8,30 @@ export default function Footer() {
     {
       name: 'AKI',
       logo: '/images/layout/aki_logo.svg',
-      url: 'https://aki-zh.ch'
+      url: 'https://aki-zh.ch',
+      width: 245,
+      height: 76,
     },
     {
       name: 'VSETH',
       logo: '/images/layout/vseth_logo.svg',
-      url: 'https://vseth.ethz.ch/'
+      url: 'https://vseth.ethz.ch/',
+      width: 458,
+      height: 121,
     },
     {
       name: 'VSUZH',
       logo: '/images/layout/vsuzh_logo.svg',
-      url: 'https://www.vsuzh.ch/'
+      url: 'https://www.vsuzh.ch/',
+      width: 4637,
+      height: 4863,
     },
     {
       name: 'UZH',
       logo: '/images/layout/uzh_logo.svg',
-      url: 'https://www.uzh.ch/'
+      url: 'https://www.uzh.ch/',
+      width: 248,
+      height: 81,
     }
   ];
 
@@ -49,6 +56,8 @@ export default function Footer() {
                 <img
                   src={sponsor.logo}
                   alt={sponsor.name}
+                  width={sponsor.width}
+                  height={sponsor.height}
                   className="h-16 md:h-20 w-auto"
                 />
               </a>

--- a/components/Navigation.tsx
+++ b/components/Navigation.tsx
@@ -25,16 +25,13 @@ export default function Navigation() {
 
   const handleLocaleChange = (newLocale: string) => {
     startTransition(() => {
-      // Check if we're on a dynamic route (has [slug] parameter)
       if (pathname === '/concerts/[slug]' && params.slug) {
-        // For dynamic routes, pass the slug as a parameter
         router.replace(
           { pathname: '/concerts/[slug]', params: { slug: params.slug as string } },
           { locale: newLocale }
         );
-      } else {
-        // For static routes, just pass the pathname
-        router.replace(pathname as any, { locale: newLocale });
+      } else if (pathname !== '/concerts/[slug]') {
+        router.replace(pathname, { locale: newLocale });
       }
     });
   };
@@ -47,7 +44,7 @@ export default function Navigation() {
       {/* Desktop Navigation */}
       <nav className="hidden md:block bg-stone-200">
         <div className="container mx-auto px-6 py-4 max-w-4xl">
-          <div className="flex items-center justify-between">
+          <div className="flex items-center justify-between min-h-7">
             {!isHomePage && (
               <Link href="/" className="text-lg font-serif font-semibold text-neutral-700 hover:text-orange-600 transition-colors">
                 Universitätsorchester Polyphonia


### PR DESCRIPTION
## Summary
- Pin the desktop navbar's inner row to `min-h-7` so it doesn't shrink ~8px on the homepage where the orchestra-name logo is hidden
- Replace the `as any` cast in the locale switcher with a type-narrowing branch
- Add explicit width/height to footer sponsor logos to avoid layout shift (kept as `<img>` because Next.js refuses to optimize SVGs by default)
- Remove an unused `next/image` import from the concert detail page

Closes #14

## Test plan
- [x] Homepage and a non-home page (e.g. `/konzerte`) — desktop navbar is the same height when toggling between them
- [x] Mobile navbar on home and non-home pages still looks correct
- [x] Footer sponsor logos render at the same size as before, no broken images
- [x] Locale switcher works on a static route (e.g. `/konzerte`) and a dynamic route (`/konzerte/fs26`)
- [x] Concert detail page (`/konzerte/fs26`) still renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)