### PR TITLE
Render ticket buttons on concert detail page

### DIFF
--- a/app/[locale]/concerts/[slug]/page.tsx
+++ b/app/[locale]/concerts/[slug]/page.tsx
@@ -30,6 +30,10 @@ export default async function ConcertPage({ params }: ConcertPageProps) {
 
     // Dynamically import the MDX file based on locale from content directory
     const Content = (await import(`@/content/concerts/${slug}/${locale}.mdx`)).default;
+    const upcomingPerformances = metadata.performances.filter(
+      p => new Date(p.date) >= new Date()
+    );
+
     return (
       <div className="max-w-4xl mx-auto px-6 pb-8">
         <Link
@@ -52,6 +56,52 @@ export default async function ConcertPage({ params }: ConcertPageProps) {
             </div>
           )}
         </div>
+
+        {upcomingPerformances.length > 0 && (
+          <div className="bg-stone-100 p-6 md:p-8 rounded-lg border border-stone-300 mt-10">
+            <div className="space-y-4">
+              {upcomingPerformances.map((performance, index) => (
+                <div
+                  key={index}
+                  className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 pb-4 border-b border-stone-300 last:border-0 last:pb-0"
+                >
+                  <div className="text-sm">
+                    <p className="font-medium text-neutral-900">
+                      {new Date(performance.date).toLocaleDateString(locale, {
+                        weekday: 'long',
+                        year: 'numeric',
+                        month: 'long',
+                        day: 'numeric'
+                      })}
+                    </p>
+                    {(performance.time || performance.location) && (
+                      <p className="text-neutral-700">
+                        {[performance.time, performance.location].filter(Boolean).join(' · ')}
+                      </p>
+                    )}
+                  </div>
+
+                  <div className="flex-shrink-0">
+                    {performance.ticketUrl ? (
+                      <a
+                        href={performance.ticketUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-block bg-orange-600 text-white px-5 py-2 rounded-full text-sm font-medium hover:bg-orange-700 transition-colors"
+                      >
+                        {t('buyTickets')} →
+                      </a>
+                    ) : (
+                      <span className="inline-block text-sm text-neutral-700 italic">
+                        {t('ticketsSoonAvailable')}
+                      </span>
+                    )}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
 
         {galleryImages.length > 0 && (
           <div className="mt-12">

--- a/content/concerts/fs26/de.mdx
+++ b/content/concerts/fs26/de.mdx
@@ -28,11 +28,3 @@ Danzón Nr. 2
 
 **William Grant Still**
 Sinfonie Nr. 1 "Afro-American"
-
-## Konzerte
-
-**Freitag, 22. Mai 2026 um 19:30 Uhr**
-Kirche Neumünster Zürich
-
-**Dienstag, 26. Mai 2026 um 19:30 Uhr**
-Kirche St. Peter Zürich

--- a/content/concerts/fs26/en.mdx
+++ b/content/concerts/fs26/en.mdx
@@ -28,11 +28,3 @@ Danzón No. 2
 
 **William Grant Still**
 Symphony No. 1 "Afro-American"
-
-## Concerts
-
-**Friday, May 22, 2026 at 19:30**
-Kirche Neumünster Zürich
-
-**Tuesday, May 26, 2026 at 19:30**
-Kirche St. Peter Zürich


### PR DESCRIPTION
## Summary
- Concert detail pages now render a ticket card below the article when there are upcoming performances, sourced from the `performances` frontmatter (matches the existing homepage card)
- FS26 detail page now exposes the Eventfrog ticket links that were already on the homepage and concerts index
- Past concerts (no upcoming performances) are unchanged
- Drops the now-redundant "## Konzerte" / "## Concerts" date listing from the FS26 MDX, since the same dates are rendered from frontmatter

## Test plan
- [ ] `/konzerte/fs26` shows the title + program, poster on the right, and a ticket card below with two "Tickets kaufen" buttons linking to Eventfrog
- [ ] `/en/concerts/fs26` same, with English copy and "Buy Tickets" buttons
- [ ] `/konzerte/hs25` (past concert) still renders correctly with the gallery and no ticket card
- [ ] Mobile view: dates and ticket buttons stack within the card

🤖 Generated with [Claude Code](https://claude.com/claude-code)