### PR TITLE
Tighten mobile padding and hyphenate long German titles

### DIFF
--- a/app/[locale]/concerts/[slug]/page.tsx
+++ b/app/[locale]/concerts/[slug]/page.tsx
@@ -35,7 +35,7 @@ export default async function ConcertPage({ params }: ConcertPageProps) {
     );
 
     return (
-      <div className="max-w-4xl mx-auto px-6 pb-8">
+      <div>
         <Link
           href="/concerts"
           className="inline-flex items-center gap-2 text-neutral-700 hover:text-orange-600 transition-colors mb-8"
@@ -47,7 +47,7 @@ export default async function ConcertPage({ params }: ConcertPageProps) {
         </Link>
 
         <div className="flex flex-col md:flex-row gap-8">
-          <article className={`prose prose-lg dark:prose-invert ${metadata.poster ? 'md:w-2/3' : 'w-full'}`}>
+          <article className={`prose prose-lg dark:prose-invert break-words hyphens-auto ${metadata.poster ? 'md:w-2/3' : 'w-full'}`}>
             <Content />
           </article>
           {metadata.poster && (

--- a/app/[locale]/concerts/page.tsx
+++ b/app/[locale]/concerts/page.tsx
@@ -34,7 +34,7 @@ export default async function ConcertsPage({
               }}
               className="block group mb-6"
             >
-              <h2 className="text-2xl font-serif font-semibold mb-3 text-neutral-900 group-hover:text-orange-600 transition-colors">
+              <h2 className="text-2xl font-serif font-semibold mb-3 text-neutral-900 group-hover:text-orange-600 transition-colors break-words hyphens-auto">
                 {concert.title}
               </h2>
               <p className="text-neutral-800">{concert.composers}</p>

--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -51,7 +51,7 @@ export default async function LocaleLayout({
       <body className={`bg-stone-200 text-neutral-900 font-sans`}>
         <NextIntlClientProvider messages={messages}>
           <Navigation />
-          <main className="container mx-auto px-6 py-20 max-w-4xl">
+          <main className="container mx-auto px-6 py-10 md:py-20 max-w-4xl">
             {children}
           </main>
           <Footer />


### PR DESCRIPTION
## Summary
- Halve top/bottom padding on `<main>` for mobile (`py-10 md:py-20`) — 80px felt heavy on small screens
- Remove the redundant `max-w-4xl mx-auto px-6 pb-8` wrapper on the concert detail page; the layout already applies these, so mobile horizontal padding was effectively doubled (48px instead of 24px)
- Add `break-words hyphens-auto` to the concert detail `<article>` and the concerts list `<h2>` so long German compounds like `Frühlingssemesterkonzert` wrap cleanly instead of overflowing or pushing `2026` onto its own line. The browser uses German hyphenation rules automatically because `<html lang={locale}>` is set in the locale layout.

## Test plan
- [x] Concert detail page (e.g. `/konzerte/fs26`) on mobile: title hyphenates inside the column, no horizontal scroll, less whitespace above "Zurück zu Konzerten"
- [x] Concerts list page (`/konzerte`) on mobile: `Frühlingssemesterkonzert 2026` and `Herbstsemesterkonzert 2025` cards don't wrap `2026` / `2025` onto a line by themselves
- [x] Desktop (`md` and up): no visible regression on padding (still `py-20`)
- [x] Other pages (about, contact, schedule, join, home): tighter top/bottom spacing on mobile but no layout breakage; homepage hero still aligns correctly with `-mt-20`

🤖 Generated with [Claude Code](https://claude.com/claude-code)