### PR TITLE
Fix bank/postal address line breaks and IBAN wrap

### DIFF
--- a/app/[locale]/about/de.mdx
+++ b/app/[locale]/about/de.mdx
@@ -95,9 +95,9 @@ Neben Polyphonia ist Gregor Bugar heute auch Dirigent des Ars Excelsis Ensembles
 
 Allgemeine Anfragen richten Sie bitte an [kontakt@polyphonia.ch](mailto:kontakt@polyphonia.ch). Für spezifische Anliegen erreichen Sie die zuständigen Vorstandsmitglieder direkt über die oben angegebenen E-Mail-Adressen.
 
-**Postadresse:**
-Universitätsorchester Polyphonia Zürich
-c/o VSUZH
-Rämistrasse 62
-8001 Zürich
+**Postadresse:**<br />
+Universitätsorchester Polyphonia Zürich<br />
+c/o VSUZH<br />
+Rämistrasse 62<br />
+8001 Zürich<br />
 Schweiz

--- a/app/[locale]/about/en.mdx
+++ b/app/[locale]/about/en.mdx
@@ -95,9 +95,9 @@ In addition to Polyphonia, Gregor Bugar is currently conductor of the Ars Excels
 
 For general inquiries, please write to [kontakt@polyphonia.ch](mailto:kontakt@polyphonia.ch). For specific concerns, you can reach the relevant board members directly via the email addresses listed above.
 
-**Mailing address:**
-Universitätsorchester Polyphonia Zürich
-c/o VSUZH
-Rämistrasse 62
-8001 Zürich
+**Mailing address:**<br />
+Universitätsorchester Polyphonia Zürich<br />
+c/o VSUZH<br />
+Rämistrasse 62<br />
+8001 Zürich<br />
 Switzerland

--- a/app/[locale]/sponsor/de.mdx
+++ b/app/[locale]/sponsor/de.mdx
@@ -80,7 +80,7 @@ Für Fragen zum Sponsoring oder zur Gönnerschaft schreiben Sie uns gerne:
 
 **E-Mail:** [sponsoring@polyphonia.ch](mailto:sponsoring@polyphonia.ch)
 
-**Bankverbindung:**
-Zürcher Kantonalbank
-Universitätsorchester Polyphonia Zürich
-IBAN: CH29 0070 0110 0065 8386 7
+**Bankverbindung:**<br />
+Zürcher Kantonalbank<br />
+Universitätsorchester Polyphonia Zürich<br />
+IBAN: <span className="whitespace-nowrap">CH29 0070 0110 0065 8386 7</span>

--- a/app/[locale]/sponsor/en.mdx
+++ b/app/[locale]/sponsor/en.mdx
@@ -80,7 +80,7 @@ For questions about sponsorship or patronage, please get in touch:
 
 **Email:** [sponsoring@polyphonia.ch](mailto:sponsoring@polyphonia.ch)
 
-**Bank details:**
-Zürcher Kantonalbank
-Universitätsorchester Polyphonia Zürich
-IBAN: CH29 0070 0110 0065 8386 7
+**Bank details:**<br />
+Zürcher Kantonalbank<br />
+Universitätsorchester Polyphonia Zürich<br />
+IBAN: <span className="whitespace-nowrap">CH29 0070 0110 0065 8386 7</span>


### PR DESCRIPTION
## Summary
Markdown soft line breaks were joining the bank-details block on the Sponsor page and the postal-address block on the About page into a single paragraph, so everything rendered on one line. The IBAN's internal spaces also let the trailing "7" wrap to its own line on desktop. Switches the affected lines to explicit \`<br />\` and wraps the IBAN in a \`whitespace-nowrap\` span so it stays together.

## Test plan
- [x] On \`/unterstuetzen\` (and \`/en/sponsor\`), the "Kontakt & Bankverbindung" section shows ZKB / orchestra name / IBAN on separate lines, with the IBAN's six groups all on one line
- [x] On \`/ueber-uns\` (and \`/en/about\`), the Kontakt section's postal address renders as five separate lines
- [x] Resize narrow enough to confirm the IBAN block wraps as a unit rather than breaking between digit groups

🤖 Generated with [Claude Code](https://claude.com/claude-code)