### PR TITLE
Show today's concert as upcoming until day ends

### DIFF
--- a/app/[locale]/concerts/[slug]/page.tsx
+++ b/app/[locale]/concerts/[slug]/page.tsx
@@ -30,8 +30,11 @@ export default async function ConcertPage({ params }: ConcertPageProps) {
 
     // Dynamically import the MDX file based on locale from content directory
     const Content = (await import(`@/content/concerts/${slug}/${locale}.mdx`)).default;
+    const todayStr = new Date().toLocaleDateString('en-CA', {
+      timeZone: 'Europe/Zurich',
+    });
     const upcomingPerformances = metadata.performances.filter(
-      p => new Date(p.date) >= new Date()
+      p => p.date >= todayStr
     );
 
     return (

--- a/app/[locale]/concerts/page.tsx
+++ b/app/[locale]/concerts/page.tsx
@@ -15,6 +15,10 @@ export default async function ConcertsPage({
   // Get all concerts with metadata from MDX frontmatter
   const concerts = getAllConcerts(locale);
 
+  const todayStr = new Date().toLocaleDateString("en-CA", {
+    timeZone: "Europe/Zurich",
+  });
+
   return (
     <div>
       <h1 className="text-4xl font-serif font-semibold mb-10 text-neutral-900">
@@ -42,8 +46,7 @@ export default async function ConcertsPage({
 
             <div className="space-y-2">
               {concert.performances.map((performance, index) => {
-                const performanceIsUpcoming =
-                  new Date(performance.date) >= new Date();
+                const performanceIsUpcoming = performance.date >= todayStr;
 
                 return (
                   <div

--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -16,8 +16,11 @@ export default async function HomePage({
   
   // Get upcoming concerts (future dates only)
   const allConcerts = getAllConcerts(locale);
+  const todayStr = new Date().toLocaleDateString('en-CA', {
+    timeZone: 'Europe/Zurich',
+  });
   const upcomingConcerts = allConcerts.filter(
-    concert => concert.performances.some(p => new Date(p.date) >= new Date())
+    concert => concert.performances.some(p => p.date >= todayStr)
   );
 
   return (
@@ -90,7 +93,7 @@ export default async function HomePage({
 
                     <div className="space-y-4">
                       {concert.performances.map((performance, index) => {
-                        const isUpcoming = new Date(performance.date) >= new Date();
+                        const isUpcoming = performance.date >= todayStr;
 
                         return (
                           <div


### PR DESCRIPTION
## Summary
- `new Date("2026-05-22") >= new Date()` is false the moment UTC midnight passes, because ISO date-only strings parse as UTC midnight while `new Date()` is the current moment. Result: a concert dated today disappears from "upcoming" lists and loses its ticket button before the concert even happens.
- Fix all three places that did this check (home page, concerts index, concert detail) by comparing the performance's `YYYY-MM-DD` string against today's date string in `Europe/Zurich`.

## Test plan
- [x] On 2026-05-22, the FS26 concert still shows on the homepage with a "Tickets kaufen" button for the 22 May performance
- [x] Same concert still appears in `/konzerte` and `/en/concerts` with the ticket link visible
- [x] Concert detail page (`/konzerte/fs26`) shows the 22 May performance in the upcoming-performances block
- [ ] After 2026-05-22 ends (Zurich time), the 22 May performance drops off / loses its ticket link, while the 26 May one remains

🤖 Generated with [Claude Code](https://claude.com/claude-code)