### PR TITLE
Add HS26 concert and enable recruitment banner

### DIFF
--- a/components/NoticeBanner.tsx
+++ b/components/NoticeBanner.tsx
@@ -29,7 +29,7 @@ export default function NoticeBanner() {
     { label: t('winds'), instruments: t('windsInstruments') },
     { label: t('brass'), instruments: t('brassInstruments') },
     { label: t('percussion'), instruments: '' },
-  ];
+  ].filter((section) => section.instruments);
 
   return (
     <div className="bg-stone-100 p-8 rounded-lg border border-stone-300">

--- a/content/concerts/hs26/de.mdx
+++ b/content/concerts/hs26/de.mdx
@@ -14,8 +14,6 @@ performances:
 
 # Herbstsemesterkonzert 2026
 
-Besuchen Sie unser Herbstkonzert mit Werken von Vaughan Williams, Chaminade und Dvořák.
-
 ## Programm
 
 ### Norfolk Rhapsody Nr. 1

--- a/content/concerts/hs26/de.mdx
+++ b/content/concerts/hs26/de.mdx
@@ -1,0 +1,38 @@
+---
+title: "Herbstsemesterkonzert 2026"
+composers: "Vaughan Williams, Chaminade, Dvořák"
+performances:
+  - date: "2026-12-17"
+    time: "19:30"
+    location: "Kirche Neumünster Zürich"
+    ticketUrl: ""
+  - date: "2026-12-18"
+    time: "19:30"
+    location: "Grosser Saal des Konservatoriums Zürich"
+    ticketUrl: ""
+---
+
+# Herbstsemesterkonzert 2026
+
+Besuchen Sie unser Herbstkonzert mit Werken von Vaughan Williams, Chaminade und Dvořák.
+
+## Programm
+
+### Norfolk Rhapsody Nr. 1
+**Ralph Vaughan Williams**
+
+### Flötenkonzertino D-Dur
+**Cécile Chaminade**
+
+### Sinfonie Nr. 5
+**Antonín Dvořák**
+
+## Konzerte
+
+**Donnerstag, 17. Dezember 2026 um 19:30 Uhr**  
+Kirche Neumünster Zürich  
+[Wegbeschreibung](https://reformiert-zuerich.ch/-4/kirchenkreis-7--8/unsere-kirchen~2469/kirche-neumunster~2552/)
+
+**Freitag, 18. Dezember 2026 um 19:30 Uhr**  
+Grosser Saal des Konservatoriums Zürich  
+[Wegbeschreibung](https://maps.app.goo.gl/GWbKrQ8MUV2DZkLs6)

--- a/content/concerts/hs26/en.mdx
+++ b/content/concerts/hs26/en.mdx
@@ -14,8 +14,6 @@ performances:
 
 # Autumn Concerts 2026
 
-Join us for our autumn concert featuring works by Vaughan Williams, Chaminade, and Dvořák.
-
 ## Program
 
 ### Norfolk Rhapsody No. 1

--- a/content/concerts/hs26/en.mdx
+++ b/content/concerts/hs26/en.mdx
@@ -1,0 +1,38 @@
+---
+title: "Autumn Concerts 2026"
+composers: "Vaughan Williams, Chaminade, Dvořák"
+performances:
+  - date: "2026-12-17"
+    time: "19:30"
+    location: "Kirche Neumünster Zürich"
+    ticketUrl: ""
+  - date: "2026-12-18"
+    time: "19:30"
+    location: "Grosser Saal des Konservatoriums Zürich"
+    ticketUrl: ""
+---
+
+# Autumn Concerts 2026
+
+Join us for our autumn concert featuring works by Vaughan Williams, Chaminade, and Dvořák.
+
+## Program
+
+### Norfolk Rhapsody No. 1
+**Ralph Vaughan Williams**
+
+### Flute Concertino in D major
+**Cécile Chaminade**
+
+### Symphony No. 5
+**Antonín Dvořák**
+
+## Concerts
+
+**Thursday, December 17, 2026 at 19:30**  
+Kirche Neumünster Zürich  
+[Directions](https://reformiert-zuerich.ch/-4/kirchenkreis-7--8/unsere-kirchen~2469/kirche-neumunster~2552/)
+
+**Friday, December 18, 2026 at 19:30**  
+Grosser Saal des Konservatoriums Zürich  
+[Directions](https://maps.app.goo.gl/GWbKrQ8MUV2DZkLs6)

--- a/lib/concerts-manifest.json
+++ b/lib/concerts-manifest.json
@@ -558,5 +558,43 @@
         }
       ]
     }
+  },
+  "hs26": {
+    "de": {
+      "title": "Herbstsemesterkonzert 2026",
+      "composers": "Vaughan Williams, Chaminade, Dvořák",
+      "performances": [
+        {
+          "date": "2026-12-17",
+          "time": "19:30",
+          "location": "Kirche Neumünster Zürich",
+          "ticketUrl": ""
+        },
+        {
+          "date": "2026-12-18",
+          "time": "19:30",
+          "location": "Grosser Saal des Konservatoriums Zürich",
+          "ticketUrl": ""
+        }
+      ]
+    },
+    "en": {
+      "title": "Autumn Concerts 2026",
+      "composers": "Vaughan Williams, Chaminade, Dvořák",
+      "performances": [
+        {
+          "date": "2026-12-17",
+          "time": "19:30",
+          "location": "Kirche Neumünster Zürich",
+          "ticketUrl": ""
+        },
+        {
+          "date": "2026-12-18",
+          "time": "19:30",
+          "location": "Grosser Saal des Konservatoriums Zürich",
+          "ticketUrl": ""
+        }
+      ]
+    }
   }
 }

--- a/lib/notice.ts
+++ b/lib/notice.ts
@@ -9,7 +9,7 @@ export interface Notice {
 }
 
 export const noticeConfig: Notice = {
-  enabled: false, // Set to true when actively recruiting
+  enabled: true, // Set to true when actively recruiting
   type: 'info',
   messageKey: 'recruitmentNotice', // Will look up 'Notice.recruitmentNotice' in translations
 };

--- a/messages/de.json
+++ b/messages/de.json
@@ -75,13 +75,13 @@
     "supportedBy": "Unterstützt von"
   },
   "Notice": {
-    "recruitmentNotice": "Wir suchen neue Mitglieder für das Frühlingssemester 2026!",
+    "recruitmentNotice": "Wir suchen neue Mitglieder für das Herbstsemester 2026!",
     "strings": "Streicher",
     "stringsInstruments": "Violine, Bratsche, Kontrabass",
     "winds": "Holzbläser",
-    "windsInstruments": "Klarinette, Englischhorn, Bassklarinette",
+    "windsInstruments": "",
     "brass": "Blechbläser",
-    "brassInstruments": "Horn, Trompete",
+    "brassInstruments": "Posaune",
     "percussion": "Schlagzeug, Banjo",
     "learnMore": "Mehr erfahren",
     "joinUs": "Mehr über das Mitmachen"

--- a/messages/en.json
+++ b/messages/en.json
@@ -75,13 +75,13 @@
     "supportedBy": "Supported by"
   },
   "Notice": {
-    "recruitmentNotice": "We are recruiting new members for spring 2026!",
+    "recruitmentNotice": "We are recruiting new members for autumn 2026!",
     "strings": "Strings",
     "stringsInstruments": "Violin, Viola, Double bass",
     "winds": "Winds",
-    "windsInstruments": "Clarinet, English horn, Bass clarinet",
+    "windsInstruments": "",
     "brass": "Brass",
-    "brassInstruments": "Horn, Trumpet",
+    "brassInstruments": "Trombone",
     "percussion": "Percussion, Banjo",
     "learnMore": "Learn More",
     "joinUs": "Learn more about joining"


### PR DESCRIPTION
## Summary
Autumn 2026 concert content + active recruitment for strings and trombone.

- **HS26 concert** (`content/concerts/hs26/de.mdx` + `en.mdx`):
  - Title: *Herbstsemesterkonzert 2026* / *Autumn Concerts 2026*
  - Program: Vaughan Williams – *Norfolk Rhapsody No. 1*; Chaminade – *Flute Concertino in D major*; Dvořák – *Symphony No. 5*
  - Performances: Thu **17 Dec 2026** 19:30, Kirche Neumünster Zürich · Fri **18 Dec 2026** 19:30, Grosser Saal des Konservatoriums Zürich
  - No poster/program PDF yet (omitted from frontmatter; can be added later)
- **Concerts manifest** regenerated to include `hs26`.
- **Recruitment banner** enabled (`lib/notice.ts`), updated translations:
  - Notice text → autumn 2026
  - `brassInstruments` → Posaune / Trombone
  - `windsInstruments` → "" (not recruiting winds this semester)
  - Strings unchanged: Violine, Bratsche, Kontrabass / Violin, Viola, Double Bass
- **NoticeBanner component** now filters out sections with no instruments, so winds and percussion don't render.

## Test plan
- [x] `pnpm build` compiles; 50 static pages (was 48 — +HS26 de/en)
- [x] `lib/concerts-manifest.json` contains `hs26` with both locales
- [x] Preview deploy: home page upcoming-concerts section now shows HS26 (Dec 17 + Dec 18)
- [x] Preview deploy: recruitment banner visible on home page with only Strings + Brass (trombone) sections
- [x] `/konzerte/hs26` and `/en/concerts/hs26` render the program + concert dates with directions links

Note: this re-applies the change that was previously reverted from main (16a5c84) so the diff is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)