### PR TITLE
Pluralize Semesterkonzerte in DE concert titles

### DIFF
--- a/content/concerts/fs26/de.mdx
+++ b/content/concerts/fs26/de.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Frühlingssemesterkonzert 2026"
+title: "Frühlingssemesterkonzerte 2026"
 composers: "Gershwin, Anderson, Márquez, Still"
 performances:
   - date: "2026-05-22"
@@ -14,7 +14,7 @@ poster: "/images/concerts/fs26.jpg"
 program: "/pdfs/Programmheft_FS26_english.pdf"
 ---
 
-# Frühlingssemesterkonzert 2026
+# Frühlingssemesterkonzerte 2026
 
 ## Programm
 

--- a/content/concerts/hs25/de.mdx
+++ b/content/concerts/hs25/de.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Herbstsemesterkonzert 2025"
+title: "Herbstsemesterkonzerte 2025"
 composers: "Borodin, Bruch, Kalinnikow"
 performances:
   - date: "2025-12-12"
@@ -12,7 +12,7 @@ performances:
     ticketUrl: ""
 ---
 
-# Herbstsemesterkonzert 2025
+# Herbstsemesterkonzerte 2025
 
 Besuchen Sie unser Herbstkonzert mit Werken von Borodin, Bruch und Kalinnikow.
 

--- a/content/concerts/hs26/de.mdx
+++ b/content/concerts/hs26/de.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Herbstsemesterkonzert 2026"
+title: "Herbstsemesterkonzerte 2026"
 composers: "Vaughan Williams, Chaminade, Dvořák"
 performances:
   - date: "2026-12-17"
@@ -12,7 +12,7 @@ performances:
     ticketUrl: ""
 ---
 
-# Herbstsemesterkonzert 2026
+# Herbstsemesterkonzerte 2026
 
 ## Programm
 

--- a/lib/concerts-manifest.json
+++ b/lib/concerts-manifest.json
@@ -201,7 +201,7 @@
   },
   "fs26": {
     "de": {
-      "title": "Frühlingssemesterkonzert 2026",
+      "title": "Frühlingssemesterkonzerte 2026",
       "composers": "Gershwin, Anderson, Márquez, Still",
       "performances": [
         {
@@ -523,7 +523,7 @@
   },
   "hs25": {
     "de": {
-      "title": "Herbstsemesterkonzert 2025",
+      "title": "Herbstsemesterkonzerte 2025",
       "composers": "Borodin, Bruch, Kalinnikow",
       "performances": [
         {
@@ -561,7 +561,7 @@
   },
   "hs26": {
     "de": {
-      "title": "Herbstsemesterkonzert 2026",
+      "title": "Herbstsemesterkonzerte 2026",
       "composers": "Vaughan Williams, Chaminade, Dvořák",
       "performances": [
         {


### PR DESCRIPTION
## Summary
Fix DE/EN inconsistency: recent concert pages used singular "Semesterkonzert" while EN says "Concerts" (plural) and older DE concerts also used plural. Each event has two performances, so plural is correct.

Affects 3 concerts (title + body heading):
- `hs25/de.mdx`: Herbstsemesterkonzert → **Herbstsemesterkonzerte** 2025
- `fs26/de.mdx`: Frühlingssemesterkonzert → **Frühlingssemesterkonzerte** 2026
- `hs26/de.mdx`: Herbstsemesterkonzert → **Herbstsemesterkonzerte** 2026

Manifest regenerated to reflect the new titles.

## Test plan
- [x] Preview deploy: `/konzerte/hs26`, `/konzerte/fs26`, `/konzerte/hs25` show the plural form in heading + browser tab title.
- [x] Concerts listing `/konzerte` shows plural titles.
- [x] Home page upcoming-concerts card for HS26 uses plural title.

🤖 Generated with [Claude Code](https://claude.com/claude-code)