### PR TITLE
Add open roles and audition dates to recruitment page

### DIFF
--- a/app/[locale]/join/de.mdx
+++ b/app/[locale]/join/de.mdx
@@ -4,6 +4,14 @@ Wir suchen immer talentierte Musikerinnen und Musiker für unser Orchester!
 
 Wir freuen uns über Bewerbungen von Studierenden und Mitarbeitenden der ETH Zürich und der Universität Zürich.
 
+## Wir suchen
+
+Für das Herbstsemester 2026 suchen wir besonders:
+
+- **Konzertmeister/-in**
+- **Streicher**: Violine, Bratsche, Kontrabass
+- **Blechbläser**: Bass- und Tenorposaune
+
 ## Wie bewerben
 
 Bitte sende eine E-Mail an [besetzung@polyphonia.ch](mailto:besetzung@polyphonia.ch) mit:
@@ -17,12 +25,16 @@ Wir freuen uns darauf, von dir zu hören!
 ## Vorspielprozess
 
 ### Für Streicher
-Das Vorspiel findet in der Form eines Quartettabends statt. Zusammen mit den Stimmführern des Orchesters spielst du Auszüge aus einem früheren Programm. So kannst du ein Gefühl für das Zusammenspiel im Orchester bekommen und uns kennenlernen.
+Das Streichervorspiel findet am 15. September 2026 statt. Es findet in der Form eines Quartettabends statt. Zusammen mit den Stimmführern des Orchesters spielst du Auszüge aus einem früheren Programm. So kannst du ein Gefühl für das Zusammenspiel im Orchester bekommen und uns kennenlernen.
 
 
 ### Für Bläser
-Für das Bläservorspiel senden wir dir einen Ausschnitt (ca. 2-3 Minuten) eines Stücks aus unserem aktuellen Programm. 
+Das Bläservorspiel findet am 14. September 2026 statt. Wir senden dir vorab einen Ausschnitt (ca. 2-3 Minuten) eines Stücks aus unserem aktuellen Programm. 
 Ausserdem bitten wir dich ein Stück deiner Wahl von ähnlicher Länge vorzubereiten und uns vorzuspielen.
+
+
+### Konzertmeister/-in
+Das Vorspiel für die Konzertmeisterposition wird separat organisiert. Bitte melde dich per E-Mail bei uns, und wir vereinbaren einen Termin mit dir.
 
 
 ## Voraussetzungen

--- a/app/[locale]/join/en.mdx
+++ b/app/[locale]/join/en.mdx
@@ -4,6 +4,14 @@ We are always looking for talented musicians to join our orchestra!
 
 We welcome applications from students and staff of ETH Zürich and the University of Zürich.
 
+## We Are Looking For
+
+For autumn 2026 we are especially looking for:
+
+- **Concert master**
+- **Strings**: Violin, Viola, Double bass
+- **Brass**: Bass and tenor trombone
+
 ## How to Apply
 
 Please send an email to [besetzung@polyphonia.ch](mailto:besetzung@polyphonia.ch) with:
@@ -17,11 +25,15 @@ We look forward to hearing from you!
 ## Audition Process
 
 ### For Strings
-Auditions typically take the form of a quartet evening. Together with the section leaders of the orchestra, you'll play excerpts from a previous program. This allows you to get a feel for playing together in the orchestra and get to know us.
+The string audition will take place on 15 September 2026. It takes the form of a quartet evening. Together with the section leaders of the orchestra, you'll play excerpts from a previous program. This allows you to get a feel for playing together in the orchestra and get to know us.
 
 
 ### For Wind and Brass
-For the wind audition, we will send you an excerpt (approx. 2–3 minutes) from a piece in our current program. In addition, we ask you to prepare a piece of your choice of similar length and perform it for us.
+The wind audition will take place on 14 September 2026. We will send you an excerpt (approx. 2–3 minutes) from a piece in our current program in advance. In addition, we ask you to prepare a piece of your choice of similar length and perform it for us.
+
+
+### Concert Master
+The audition for the concert master position is organized separately. Please get in touch with us by email and we'll arrange a time with you.
 
 
 ## Requirements

--- a/components/NoticeBanner.tsx
+++ b/components/NoticeBanner.tsx
@@ -38,6 +38,9 @@ export default function NoticeBanner() {
           {t(noticeConfig.messageKey)}
         </h3>
         <div className="text-neutral-700 mb-4 space-y-2">
+          <div>
+            <span className="font-medium">{t('concertmaster')}</span>
+          </div>
           {sections.map((section, index) => (
             <div key={index}>
               <span className="font-medium">{section.label}</span>

--- a/messages/de.json
+++ b/messages/de.json
@@ -76,12 +76,13 @@
   },
   "Notice": {
     "recruitmentNotice": "Wir suchen neue Mitglieder für das Herbstsemester 2026!",
+    "concertmaster": "Konzertmeister/-in",
     "strings": "Streicher",
     "stringsInstruments": "Violine, Bratsche, Kontrabass",
     "winds": "Holzbläser",
     "windsInstruments": "",
     "brass": "Blechbläser",
-    "brassInstruments": "Posaune",
+    "brassInstruments": "Bass- und Tenorposaune",
     "percussion": "Schlagzeug, Banjo",
     "learnMore": "Mehr erfahren",
     "joinUs": "Mehr über das Mitmachen"

--- a/messages/en.json
+++ b/messages/en.json
@@ -76,12 +76,13 @@
   },
   "Notice": {
     "recruitmentNotice": "We are recruiting new members for autumn 2026!",
+    "concertmaster": "Concert master",
     "strings": "Strings",
     "stringsInstruments": "Violin, Viola, Double bass",
     "winds": "Winds",
     "windsInstruments": "",
     "brass": "Brass",
-    "brassInstruments": "Trombone",
+    "brassInstruments": "Bass and tenor trombone",
     "percussion": "Percussion, Banjo",
     "learnMore": "Learn More",
     "joinUs": "Learn more about joining"


### PR DESCRIPTION
## Summary
- Add a "We Are Looking For" section to the `/join` page listing concert master, strings (violin, viola, double bass), and brass (bass & tenor trombone) openings (DE + EN)
- Refine the notice banner: add a concert master line and change trombone wording to "bass and tenor trombone"
- Add audition dates — wind on 14 September 2026, strings on 15 September 2026 — and a note that the concert master audition is organized separately

## Test plan
- [ ] `pnpm dev` and visit `/mitmachen` and `/en/join` — verify the new roles and audition dates render in both locales
- [ ] Visit `/` — verify the notice banner shows the concert master line and "Bass- und Tenorposaune" / "Bass and tenor trombone"

🤖 Generated with [Claude Code](https://claude.com/claude-code)