### PR TITLE
Add autumn 2026 schedule and make section filters more prominent

### DIFF
--- a/app/[locale]/join/de.mdx
+++ b/app/[locale]/join/de.mdx
@@ -4,6 +4,14 @@ Wir suchen immer talentierte Musikerinnen und Musiker für unser Orchester!
 
 Wir freuen uns über Bewerbungen von Studierenden und Mitarbeitenden der ETH Zürich und der Universität Zürich.
 
+## Wir suchen
+
+Für das Herbstsemester 2026 suchen wir besonders:
+
+- **Konzertmeister/-in**
+- **Streicher**: Violine, Bratsche, Kontrabass
+- **Blechbläser**: Bass- und Tenorposaune
+
 ## Wie bewerben
 
 Bitte sende eine E-Mail an [besetzung@polyphonia.ch](mailto:besetzung@polyphonia.ch) mit:
@@ -17,12 +25,16 @@ Wir freuen uns darauf, von dir zu hören!
 ## Vorspielprozess
 
 ### Für Streicher
-Das Vorspiel findet in der Form eines Quartettabends statt. Zusammen mit den Stimmführern des Orchesters spielst du Auszüge aus einem früheren Programm. So kannst du ein Gefühl für das Zusammenspiel im Orchester bekommen und uns kennenlernen.
+Das Streichervorspiel findet am 15. September 2026 statt. Es findet in der Form eines Quartettabends statt. Zusammen mit den Stimmführern des Orchesters spielst du Auszüge aus einem früheren Programm. So kannst du ein Gefühl für das Zusammenspiel im Orchester bekommen und uns kennenlernen.
 
 
 ### Für Bläser
-Für das Bläservorspiel senden wir dir einen Ausschnitt (ca. 2-3 Minuten) eines Stücks aus unserem aktuellen Programm. 
+Das Bläservorspiel findet am 14. September 2026 statt. Wir senden dir vorab einen Ausschnitt (ca. 2-3 Minuten) eines Stücks aus unserem aktuellen Programm. 
 Ausserdem bitten wir dich ein Stück deiner Wahl von ähnlicher Länge vorzubereiten und uns vorzuspielen.
+
+
+### Konzertmeister/-in
+Das Vorspiel für die Konzertmeisterposition wird separat organisiert. Bitte melde dich per E-Mail bei uns, und wir vereinbaren einen Termin mit dir.
 
 
 ## Voraussetzungen

--- a/app/[locale]/join/de.mdx
+++ b/app/[locale]/join/de.mdx
@@ -12,6 +12,8 @@ Für das Herbstsemester 2026 suchen wir besonders:
 - **Streicher**: Violine, Bratsche, Kontrabass
 - **Blechbläser**: Bass- und Tenorposaune
 
+Was du vorbereiten solltest, findest du im [Vorspielprozess](#audition-process) weiter unten.
+
 ## Wie bewerben
 
 Bitte sende eine E-Mail an [besetzung@polyphonia.ch](mailto:besetzung@polyphonia.ch) mit:
@@ -22,19 +24,24 @@ Bitte sende eine E-Mail an [besetzung@polyphonia.ch](mailto:besetzung@polyphonia
 
 Wir freuen uns darauf, von dir zu hören!
 
-## Vorspielprozess
+<h2 id="audition-process">Vorspielprozess</h2>
+
+### Konzertmeister/-in
+Für das Vorspiel als Konzertmeister/-in bereite bitte vor:
+
+- den ersten Satz, inklusive Kadenz, eines der Violinkonzerte von Mozart — Nr. 3, 4 oder 5
+- ein Streichquartett, das wir dir vorab zusenden
+
+Das Vorspiel wird separat organisiert. Bitte melde dich per E-Mail bei uns, und wir vereinbaren einen Termin mit dir.
+
 
 ### Für Streicher
-Das Streichervorspiel findet am 15. September 2026 statt. Es findet in der Form eines Quartettabends statt. Zusammen mit den Stimmführern des Orchesters spielst du Auszüge aus einem früheren Programm. So kannst du ein Gefühl für das Zusammenspiel im Orchester bekommen und uns kennenlernen.
+Das Streichervorspiel findet am 15. September 2026 statt. Wir senden dir vorab einen Ausschnitt aus einem bestimmten Stück sowie ein Streichquartett zur Vorbereitung zu. Zusammen mit den Stimmführern des Orchesters spielst du diese — so bekommst du ein Gefühl für das Zusammenspiel im Orchester und kannst uns kennenlernen.
 
 
 ### Für Bläser
 Das Bläservorspiel findet am 14. September 2026 statt. Wir senden dir vorab einen Ausschnitt (ca. 2-3 Minuten) eines Stücks aus unserem aktuellen Programm. 
 Ausserdem bitten wir dich ein Stück deiner Wahl von ähnlicher Länge vorzubereiten und uns vorzuspielen.
-
-
-### Konzertmeister/-in
-Das Vorspiel für die Konzertmeisterposition wird separat organisiert. Bitte melde dich per E-Mail bei uns, und wir vereinbaren einen Termin mit dir.
 
 
 ## Voraussetzungen

--- a/app/[locale]/join/en.mdx
+++ b/app/[locale]/join/en.mdx
@@ -4,6 +4,14 @@ We are always looking for talented musicians to join our orchestra!
 
 We welcome applications from students and staff of ETH Zürich and the University of Zürich.
 
+## We Are Looking For
+
+For autumn 2026 we are especially looking for:
+
+- **Concert master**
+- **Strings**: Violin, Viola, Double bass
+- **Brass**: Bass and tenor trombone
+
 ## How to Apply
 
 Please send an email to [besetzung@polyphonia.ch](mailto:besetzung@polyphonia.ch) with:
@@ -17,11 +25,15 @@ We look forward to hearing from you!
 ## Audition Process
 
 ### For Strings
-Auditions typically take the form of a quartet evening. Together with the section leaders of the orchestra, you'll play excerpts from a previous program. This allows you to get a feel for playing together in the orchestra and get to know us.
+The string audition will take place on 15 September 2026. It takes the form of a quartet evening. Together with the section leaders of the orchestra, you'll play excerpts from a previous program. This allows you to get a feel for playing together in the orchestra and get to know us.
 
 
 ### For Wind and Brass
-For the wind audition, we will send you an excerpt (approx. 2–3 minutes) from a piece in our current program. In addition, we ask you to prepare a piece of your choice of similar length and perform it for us.
+The wind audition will take place on 14 September 2026. We will send you an excerpt (approx. 2–3 minutes) from a piece in our current program in advance. In addition, we ask you to prepare a piece of your choice of similar length and perform it for us.
+
+
+### Concert Master
+The audition for the concert master position is organized separately. Please get in touch with us by email and we'll arrange a time with you.
 
 
 ## Requirements

--- a/app/[locale]/join/en.mdx
+++ b/app/[locale]/join/en.mdx
@@ -8,9 +8,11 @@ We welcome applications from students and staff of ETH Zürich and the Universit
 
 For autumn 2026 we are especially looking for:
 
-- **Concert master**
+- **Concertmaster**
 - **Strings**: Violin, Viola, Double bass
 - **Brass**: Bass and tenor trombone
+
+See the [audition process](#audition-process) below for what to prepare.
 
 ## How to Apply
 
@@ -22,18 +24,23 @@ Please send an email to [besetzung@polyphonia.ch](mailto:besetzung@polyphonia.ch
 
 We look forward to hearing from you!
 
-## Audition Process
+<h2 id="audition-process">Audition Process</h2>
+
+### Concertmaster
+For the concertmaster audition, please prepare:
+
+- The first movement, including a cadenza, of one of Mozart's violin concertos — No. 3, 4, or 5
+- A string quartet, which we will send you in advance
+
+The audition is organized separately. Please get in touch with us by email and we'll arrange a time with you.
+
 
 ### For Strings
-The string audition will take place on 15 September 2026. It takes the form of a quartet evening. Together with the section leaders of the orchestra, you'll play excerpts from a previous program. This allows you to get a feel for playing together in the orchestra and get to know us.
+The string audition will take place on 15 September 2026. We will send you an excerpt from a specific piece, along with a string quartet, to prepare in advance. Together with the section leaders of the orchestra, you'll play these — giving you a feel for playing together in the orchestra and a chance to get to know us.
 
 
 ### For Wind and Brass
 The wind audition will take place on 14 September 2026. We will send you an excerpt (approx. 2–3 minutes) from a piece in our current program in advance. In addition, we ask you to prepare a piece of your choice of similar length and perform it for us.
-
-
-### Concert Master
-The audition for the concert master position is organized separately. Please get in touch with us by email and we'll arrange a time with you.
 
 
 ## Requirements

--- a/app/[locale]/schedule/page.tsx
+++ b/app/[locale]/schedule/page.tsx
@@ -46,11 +46,11 @@ export default async function SchedulePage({
       <p className="text-neutral-800 mb-10 text-sm">{t("subtitle")}</p>
 
       <div className="mb-6">
-        <DownloadICSButton locale={locale} />
+        <FilterMenu activeSection={section} />
       </div>
 
       <div className="mb-6">
-        <FilterMenu activeSection={section} />
+        <DownloadICSButton locale={locale} />
       </div>
 
       <RehearsalItems groupedRehearsals={groupedRehearsals} locale={locale} />

--- a/app/[locale]/schedule/page.tsx
+++ b/app/[locale]/schedule/page.tsx
@@ -43,7 +43,8 @@ export default async function SchedulePage({
       <h1 className="text-4xl font-serif font-semibold mb-3 text-neutral-900">
         {t("title")}
       </h1>
-      <p className="text-neutral-800 mb-10 text-sm">{t("subtitle")}</p>
+      <p className="text-neutral-800 mb-2 text-sm">{t("subtitle")}</p>
+      <p className="text-neutral-800 mb-10 text-sm">{t("arrivalNote")}</p>
 
       <div className="mb-6">
         <FilterMenu activeSection={section} />

--- a/components/NoticeBanner.tsx
+++ b/components/NoticeBanner.tsx
@@ -38,6 +38,9 @@ export default function NoticeBanner() {
           {t(noticeConfig.messageKey)}
         </h3>
         <div className="text-neutral-700 mb-4 space-y-2">
+          <div>
+            <span className="font-medium">{t('concertmaster')}</span>
+          </div>
           {sections.map((section, index) => (
             <div key={index}>
               <span className="font-medium">{section.label}</span>

--- a/components/NoticeBanner.tsx
+++ b/components/NoticeBanner.tsx
@@ -37,17 +37,17 @@ export default function NoticeBanner() {
         <h3 className="text-xl font-serif font-semibold mb-4 text-neutral-900 group-hover:text-orange-600 transition-colors">
           {t(noticeConfig.messageKey)}
         </h3>
-        <div className="text-neutral-700 mb-4 space-y-2">
-          <div>
+        <ul className="text-neutral-700 mb-4 space-y-2 list-disc pl-5 marker:text-orange-600">
+          <li>
             <span className="font-medium">{t('concertmaster')}</span>
-          </div>
+          </li>
           {sections.map((section, index) => (
-            <div key={index}>
+            <li key={index}>
               <span className="font-medium">{section.label}</span>
               {section.instruments && <>: {section.instruments}</>}
-            </div>
+            </li>
           ))}
-        </div>
+        </ul>
         <span className="text-sm text-orange-600 group-hover:text-orange-700 transition-colors">
           {t('joinUs')} →
         </span>

--- a/components/schedule/FilterMenu.tsx
+++ b/components/schedule/FilterMenu.tsx
@@ -35,17 +35,20 @@ export function FilterMenu({
 
   return (
     <div className="flex flex-wrap items-center gap-2">
-      <span className="text-sm text-neutral-500">{t("filterLabel")}</span>
+      <span className="mr-1 text-sm font-semibold uppercase tracking-wide text-neutral-700">
+        {t("filterLabel")}
+      </span>
       {SECTIONS.map((section) => {
         const isActive = activeSection === section;
         return (
           <button
             key={section}
             onClick={() => selectSection(section)}
-            className={`rounded-full px-3 py-1 text-sm transition-colors ${
+            aria-pressed={isActive}
+            className={`rounded-full border px-4 py-2 text-sm font-medium transition-colors ${
               isActive
-                ? "bg-orange-100 text-orange-800"
-                : "text-neutral-500 hover:bg-neutral-100 hover:text-neutral-700"
+                ? "border-orange-600 bg-orange-600 text-white"
+                : "border-stone-300 text-neutral-700 hover:border-orange-400 hover:text-orange-700"
             }`}
           >
             {labels[section]}

--- a/components/schedule/FilterMenu.tsx
+++ b/components/schedule/FilterMenu.tsx
@@ -35,7 +35,7 @@ export function FilterMenu({
 
   return (
     <div className="flex flex-wrap items-center gap-2">
-      <span className="mr-1 text-sm font-semibold uppercase tracking-wide text-neutral-700">
+      <span className="mr-1 text-sm font-semibold text-neutral-700">
         {t("filterLabel")}
       </span>
       {SECTIONS.map((section) => {

--- a/content/schedule/rehearsals.json
+++ b/content/schedule/rehearsals.json
@@ -1,179 +1,177 @@
 [
   {
-    "date": "2026-02-18",
-    "time": "18:00-21:00",
+    "date": "2026-09-16",
+    "time": "18:15-21:00",
     "location": "Aki Hirschengraben 86, 8001 Zürich",
     "notes_de": "Leseprobe (Tutti)",
     "notes_en": "Sight-reading rehearsal (Tutti)",
     "section": "tutti"
   },
   {
-    "date": "2026-02-22",
-    "time": "10:00-16:00",
-    "location": "TBA",
-    "notes_de": "Streicherprobe",
-    "notes_en": "String sectional",
-    "section": "strings"
-  },
-  {
-    "date": "2026-02-25",
-    "time": "18:00-21:00",
+    "date": "2026-09-23",
+    "time": "18:15-21:00",
     "location": "Aki Hirschengraben 86, 8001 Zürich",
-    "notes_de": "Tutti (Márquez & Gershwin)",
-    "notes_en": "Tutti (Márquez & Gershwin)",
+    "notes_de": "Tutti (Dvořák)",
+    "notes_en": "Tutti (Dvořák)",
     "section": "tutti"
   },
   {
-    "date": "2026-03-04",
-    "time": "18:00-21:00",
+    "date": "2026-09-29",
+    "time": "18:15-21:00",
     "location": "Aki Hirschengraben 86, 8001 Zürich",
-    "notes_de": "Tutti (Anderson & Still)",
-    "notes_en": "Tutti (Anderson & Still)",
-    "section": "tutti"
-  },
-  {
-    "date": "2026-03-05",
-    "time": "18:00-21:00",
-    "location": "RAA-E-08 Rämistrasse 59, 8001 Zürich",
-    "notes_de": "Holzbläser (Márquez & Gershwin)",
-    "notes_en": "Woodwinds (Márquez & Gershwin)",
+    "notes_de": "Holzbläser (Dvořák + ev. Rest)",
+    "notes_en": "Woodwinds (Dvořák + poss. rest)",
     "section": "woodwinds"
   },
   {
-    "date": "2026-03-10",
-    "time": "18:00-21:00",
-    "location": "RAA-E-08 Rämistrasse 59, 8001 Zürich",
-    "notes_de": "Blechbläser (Márquez & Gershwin)",
-    "notes_en": "Brass (Márquez & Gershwin)",
+    "date": "2026-09-30",
+    "time": "18:15-21:00",
+    "location": "Aki Hirschengraben 86, 8001 Zürich",
+    "notes_de": "Tutti (Williams & Chaminade & ev. Dvořák)",
+    "notes_en": "Tutti (Williams & Chaminade & poss. Dvořák)",
+    "section": "tutti"
+  },
+  {
+    "date": "2026-10-01",
+    "time": "18:15-21:00",
+    "location": "Aki Hirschengraben 86, 8001 Zürich",
+    "notes_de": "Blechbläser (Dvořák + ev. Rest)",
+    "notes_en": "Brass (Dvořák + poss. rest)",
     "section": "brass"
   },
   {
-    "date": "2026-03-11",
-    "time": "18:00-21:00",
+    "date": "2026-10-07",
+    "time": "18:15-21:00",
     "location": "Aki Hirschengraben 86, 8001 Zürich",
-    "notes_de": "Streicher (Márquez & Gershwin)",
-    "notes_en": "Strings (Márquez & Gershwin)",
+    "notes_de": "Streicher (Dvořák)",
+    "notes_en": "Strings (Dvořák)",
     "section": "strings"
   },
   {
-    "date": "2026-03-12",
-    "time": "18:00-21:00",
-    "location": "RAA-E-08 Rämistrasse 59, 8001 Zürich",
-    "notes_de": "Holzbläser (Anderson & Still)",
-    "notes_en": "Woodwinds (Anderson & Still)",
+    "date": "2026-10-08",
+    "time": "18:15-21:00",
+    "location": "Aki Hirschengraben 86, 8001 Zürich",
+    "notes_de": "Holzbläser (Williams & Chaminade & ev. Dvořák)",
+    "notes_en": "Woodwinds (Williams & Chaminade & poss. Dvořák)",
     "section": "woodwinds"
   },
   {
-    "date": "2026-03-18",
-    "time": "18:00-21:00",
+    "date": "2026-10-13",
+    "time": "18:15-21:00",
     "location": "Aki Hirschengraben 86, 8001 Zürich",
-    "notes_de": "Streicher (Anderson & Still)",
-    "notes_en": "Strings (Anderson & Still)",
-    "section": "strings"
-  },
-  {
-    "date": "2026-03-19",
-    "time": "18:00-21:00",
-    "location": "RAA-E-08 Rämistrasse 59, 8001 Zürich",
-    "notes_de": "Blechbläser (Anderson & Still)",
-    "notes_en": "Brass (Anderson & Still)",
+    "notes_de": "Blechbläser (Williams & Chaminade & ev. Dvořák)",
+    "notes_en": "Brass (Williams & Chaminade & poss. Dvořák)",
     "section": "brass"
   },
   {
-    "date": "2026-03-25",
-    "time": "18:00-21:00",
+    "date": "2026-10-14",
+    "time": "18:15-21:00",
     "location": "Aki Hirschengraben 86, 8001 Zürich",
-    "notes_de": "Tutti (Márquez & Gershwin)",
-    "notes_en": "Tutti (Márquez & Gershwin)",
+    "notes_de": "Streicher (Williams & Chaminade & ev. Dvořák)",
+    "notes_en": "Strings (Williams & Chaminade & poss. Dvořák)",
+    "section": "strings"
+  },
+  {
+    "date": "2026-10-21",
+    "time": "18:15-21:00",
+    "location": "Aki Hirschengraben 86, 8001 Zürich",
+    "notes_de": "Tutti (Dvořák 4+1)",
+    "notes_en": "Tutti (Dvořák 4+1)",
     "section": "tutti"
   },
   {
-    "date": "2026-04-01",
-    "time": "18:00-21:00",
+    "date": "2026-10-28",
+    "time": "18:15-21:00",
     "location": "Aki Hirschengraben 86, 8001 Zürich",
-    "notes_de": "Tutti (Anderson & Still)",
-    "notes_en": "Tutti (Anderson & Still)",
+    "notes_de": "Tutti (Dvořák 3+2)",
+    "notes_en": "Tutti (Dvořák 3+2)",
     "section": "tutti"
   },
   {
-    "date": "2026-04-15",
-    "time": "18:00-21:00",
+    "date": "2026-11-01",
+    "time": "10:00-13:00 / 14:00-17:00",
+    "location": "Aki Hirschengraben 86, 8001 Zürich",
+    "notes_de": "Vormittag: Dvořák / Nachmittag: restliches Programm (ev. Dvořák)",
+    "notes_en": "Morning: Dvořák / Afternoon: rest of program (poss. Dvořák)",
+    "section": "tutti",
+    "highlight": true
+  },
+  {
+    "date": "2026-11-04",
+    "time": "18:15-21:00",
+    "location": "Aki Hirschengraben 86, 8001 Zürich",
+    "notes_de": "Tutti (Williams & Chaminade)",
+    "notes_en": "Tutti (Williams & Chaminade)",
+    "section": "tutti"
+  },
+  {
+    "date": "2026-11-11",
+    "time": "18:15-21:00",
+    "location": "Aki Hirschengraben 86, 8001 Zürich",
+    "notes_de": "Holz- & Blechbläser (mit Gregor)",
+    "notes_en": "Woodwinds & Brass (with Gregor)",
+    "section": "winds"
+  },
+  {
+    "date": "2026-11-11",
+    "time": "18:15-21:00",
     "location": "Aki Hirschengraben 86, 8001 Zürich",
     "notes_de": "Streicherregisterprobe (mit Stimmführern)",
-    "notes_en": "String Sectionals (with section leader)",
+    "notes_en": "String sectionals (with section leaders)",
     "section": "strings"
   },
   {
-    "date": "2026-04-15",
-    "time": "18:00-21:00",
+    "date": "2026-11-18",
+    "time": "18:15-21:00",
     "location": "Aki Hirschengraben 86, 8001 Zürich",
-    "notes_de": "Bläser & Perkussion (mit Gregor)",
-    "notes_en": "Winds & Percussion (with Gregor)",
-    "section": "winds"
-  },
-  {
-    "date": "2026-04-22",
-    "time": "18:00-21:00",
-    "location": "Aki Hirschengraben 86, 8001 Zürich",
-    "notes_de": "Tutti (Márquez & Gershwin)",
-    "notes_en": "Tutti (Márquez & Gershwin)",
+    "notes_de": "Tutti (Dvořák 1+4)",
+    "notes_en": "Tutti (Dvořák 1+4)",
     "section": "tutti"
   },
   {
-    "date": "2026-04-23",
-    "time": "18:00-21:00",
+    "date": "2026-11-25",
+    "time": "18:15-21:00",
     "location": "Aki Hirschengraben 86, 8001 Zürich",
-    "notes_de": "Bläser",
-    "notes_en": "Winds",
-    "section": "winds"
-  },
-  {
-    "date": "2026-04-29",
-    "time": "18:00-21:00",
-    "location": "Aki Hirschengraben 86, 8001 Zürich",
-    "notes_de": "Tutti (Anderson & Still)",
-    "notes_en": "Tutti (Anderson & Still)",
+    "notes_de": "Tutti (Dvořák 2+3)",
+    "notes_en": "Tutti (Dvořák 2+3)",
     "section": "tutti"
   },
   {
-    "date": "2026-05-01",
-    "date_end": "2026-05-03",
-    "time": "",
-    "time_de": "Fr 1. - So 3. Mai",
-    "time_en": "Fri 1 - Sun 3 May",
-    "location": "Vignogn",
-    "notes_de": "Probewochenende",
-    "notes_en": "Rehearsal weekend",
+    "date": "2026-12-02",
+    "time": "18:15-21:00",
+    "location": "Aki Hirschengraben 86, 8001 Zürich",
+    "notes_de": "Tutti (Williams & Chaminade + ev. Dvořák)",
+    "notes_en": "Tutti (Williams & Chaminade + poss. Dvořák)",
+    "section": "tutti"
+  },
+  {
+    "date": "2026-12-06",
+    "time": "10:00-13:00 / 14:00-17:00",
+    "location": "Aki Hirschengraben 86, 8001 Zürich",
+    "notes_de": "Vormittag: Dvořák / Nachmittag: alles",
+    "notes_en": "Morning: Dvořák / Afternoon: everything",
     "section": "tutti",
     "highlight": true
   },
   {
-    "date": "2026-05-06",
-    "time": "18:00-21:00",
+    "date": "2026-12-09",
+    "time": "18:15-21:00",
     "location": "Aki Hirschengraben 86, 8001 Zürich",
-    "notes_de": "Tutti",
-    "notes_en": "Tutti",
+    "notes_de": "Dvořák (1+2+3+4)",
+    "notes_en": "Dvořák (1+2+3+4)",
     "section": "tutti"
   },
   {
-    "date": "2026-05-13",
-    "time": "18:00-21:00",
+    "date": "2026-12-16",
+    "time": "18:15-21:00",
     "location": "Aki Hirschengraben 86, 8001 Zürich",
-    "notes_de": "Tutti",
-    "notes_en": "Tutti",
-    "section": "tutti"
-  },
-  {
-    "date": "2026-05-20",
-    "time": "18:00-21:00",
-    "location": "TBD",
-    "notes_de": "Generalprobe",
-    "notes_en": "Dress rehearsal",
+    "notes_de": "Generalprobe (Konzertreihenfolge + Korrekturen)",
+    "notes_en": "Dress rehearsal (concert order + corrections)",
     "section": "tutti",
     "highlight": true
   },
   {
-    "date": "2026-05-22",
+    "date": "2026-12-17",
     "time": "19:30-22:00",
     "location": "Kirche Neumünster",
     "notes_de": "Konzert",
@@ -182,9 +180,9 @@
     "highlight": true
   },
   {
-    "date": "2026-05-26",
+    "date": "2026-12-18",
     "time": "19:30-22:00",
-    "location": "Kirche St. Peter",
+    "location": "Grosser Saal des Konservatoriums Zürich",
     "notes_de": "Konzert",
     "notes_en": "Concert",
     "section": "tutti",

--- a/content/schedule/rehearsals.json
+++ b/content/schedule/rehearsals.json
@@ -1,7 +1,7 @@
 [
   {
     "date": "2026-09-16",
-    "time": "18:15-21:00",
+    "time": "18:00-21:00",
     "location": "Aki Hirschengraben 86, 8001 Zürich",
     "notes_de": "Leseprobe (Tutti)",
     "notes_en": "Sight-reading rehearsal (Tutti)",
@@ -9,7 +9,7 @@
   },
   {
     "date": "2026-09-23",
-    "time": "18:15-21:00",
+    "time": "18:00-21:00",
     "location": "Aki Hirschengraben 86, 8001 Zürich",
     "notes_de": "Tutti (Dvořák)",
     "notes_en": "Tutti (Dvořák)",
@@ -17,7 +17,7 @@
   },
   {
     "date": "2026-09-29",
-    "time": "18:15-21:00",
+    "time": "18:00-21:00",
     "location": "Aki Hirschengraben 86, 8001 Zürich",
     "notes_de": "Holzbläser (Dvořák + ev. Rest)",
     "notes_en": "Woodwinds (Dvořák + poss. rest)",
@@ -25,7 +25,7 @@
   },
   {
     "date": "2026-09-30",
-    "time": "18:15-21:00",
+    "time": "18:00-21:00",
     "location": "Aki Hirschengraben 86, 8001 Zürich",
     "notes_de": "Tutti (Williams & Chaminade & ev. Dvořák)",
     "notes_en": "Tutti (Williams & Chaminade & poss. Dvořák)",
@@ -33,7 +33,7 @@
   },
   {
     "date": "2026-10-01",
-    "time": "18:15-21:00",
+    "time": "18:00-21:00",
     "location": "Aki Hirschengraben 86, 8001 Zürich",
     "notes_de": "Blechbläser (Dvořák + ev. Rest)",
     "notes_en": "Brass (Dvořák + poss. rest)",
@@ -41,7 +41,7 @@
   },
   {
     "date": "2026-10-07",
-    "time": "18:15-21:00",
+    "time": "18:00-21:00",
     "location": "Aki Hirschengraben 86, 8001 Zürich",
     "notes_de": "Streicher (Dvořák)",
     "notes_en": "Strings (Dvořák)",
@@ -49,7 +49,7 @@
   },
   {
     "date": "2026-10-08",
-    "time": "18:15-21:00",
+    "time": "18:00-21:00",
     "location": "Aki Hirschengraben 86, 8001 Zürich",
     "notes_de": "Holzbläser (Williams & Chaminade & ev. Dvořák)",
     "notes_en": "Woodwinds (Williams & Chaminade & poss. Dvořák)",
@@ -57,7 +57,7 @@
   },
   {
     "date": "2026-10-13",
-    "time": "18:15-21:00",
+    "time": "18:00-21:00",
     "location": "Aki Hirschengraben 86, 8001 Zürich",
     "notes_de": "Blechbläser (Williams & Chaminade & ev. Dvořák)",
     "notes_en": "Brass (Williams & Chaminade & poss. Dvořák)",
@@ -65,7 +65,7 @@
   },
   {
     "date": "2026-10-14",
-    "time": "18:15-21:00",
+    "time": "18:00-21:00",
     "location": "Aki Hirschengraben 86, 8001 Zürich",
     "notes_de": "Streicher (Williams & Chaminade & ev. Dvořák)",
     "notes_en": "Strings (Williams & Chaminade & poss. Dvořák)",
@@ -73,7 +73,7 @@
   },
   {
     "date": "2026-10-21",
-    "time": "18:15-21:00",
+    "time": "18:00-21:00",
     "location": "Aki Hirschengraben 86, 8001 Zürich",
     "notes_de": "Tutti (Dvořák 4+1)",
     "notes_en": "Tutti (Dvořák 4+1)",
@@ -81,7 +81,7 @@
   },
   {
     "date": "2026-10-28",
-    "time": "18:15-21:00",
+    "time": "18:00-21:00",
     "location": "Aki Hirschengraben 86, 8001 Zürich",
     "notes_de": "Tutti (Dvořák 3+2)",
     "notes_en": "Tutti (Dvořák 3+2)",
@@ -98,7 +98,7 @@
   },
   {
     "date": "2026-11-04",
-    "time": "18:15-21:00",
+    "time": "18:00-21:00",
     "location": "Aki Hirschengraben 86, 8001 Zürich",
     "notes_de": "Tutti (Williams & Chaminade)",
     "notes_en": "Tutti (Williams & Chaminade)",
@@ -106,7 +106,7 @@
   },
   {
     "date": "2026-11-11",
-    "time": "18:15-21:00",
+    "time": "18:00-21:00",
     "location": "Aki Hirschengraben 86, 8001 Zürich",
     "notes_de": "Holz- & Blechbläser (mit Gregor)",
     "notes_en": "Woodwinds & Brass (with Gregor)",
@@ -114,7 +114,7 @@
   },
   {
     "date": "2026-11-11",
-    "time": "18:15-21:00",
+    "time": "18:00-21:00",
     "location": "Aki Hirschengraben 86, 8001 Zürich",
     "notes_de": "Streicherregisterprobe (mit Stimmführern)",
     "notes_en": "String sectionals (with section leaders)",
@@ -122,7 +122,7 @@
   },
   {
     "date": "2026-11-18",
-    "time": "18:15-21:00",
+    "time": "18:00-21:00",
     "location": "Aki Hirschengraben 86, 8001 Zürich",
     "notes_de": "Tutti (Dvořák 1+4)",
     "notes_en": "Tutti (Dvořák 1+4)",
@@ -130,7 +130,7 @@
   },
   {
     "date": "2026-11-25",
-    "time": "18:15-21:00",
+    "time": "18:00-21:00",
     "location": "Aki Hirschengraben 86, 8001 Zürich",
     "notes_de": "Tutti (Dvořák 2+3)",
     "notes_en": "Tutti (Dvořák 2+3)",
@@ -138,7 +138,7 @@
   },
   {
     "date": "2026-12-02",
-    "time": "18:15-21:00",
+    "time": "18:00-21:00",
     "location": "Aki Hirschengraben 86, 8001 Zürich",
     "notes_de": "Tutti (Williams & Chaminade + ev. Dvořák)",
     "notes_en": "Tutti (Williams & Chaminade + poss. Dvořák)",
@@ -155,7 +155,7 @@
   },
   {
     "date": "2026-12-09",
-    "time": "18:15-21:00",
+    "time": "18:00-21:00",
     "location": "Aki Hirschengraben 86, 8001 Zürich",
     "notes_de": "Dvořák (1+2+3+4)",
     "notes_en": "Dvořák (1+2+3+4)",
@@ -163,7 +163,7 @@
   },
   {
     "date": "2026-12-16",
-    "time": "18:15-21:00",
+    "time": "18:00-21:00",
     "location": "Aki Hirschengraben 86, 8001 Zürich",
     "notes_de": "Generalprobe (Konzertreihenfolge + Korrekturen)",
     "notes_en": "Dress rehearsal (concert order + corrections)",

--- a/messages/de.json
+++ b/messages/de.json
@@ -45,6 +45,7 @@
   "Schedule": {
     "title": "Probenplan",
     "subtitle": "Sofern nicht anders angegeben, finden die Proben im Aki, Hirschengraben 86, 8001 Zürich statt.",
+    "arrivalNote": "Bitte sei um 18:00 Uhr da, um aufzubauen, dich aufzuwärmen und zu stimmen — die Probe beginnt um 18:15 Uhr. Die Teilnahme an hervorgehobenen Terminen ist verpflichtend.",
     "date": "Datum",
     "time": "Zeit",
     "location": "Ort",

--- a/messages/de.json
+++ b/messages/de.json
@@ -76,12 +76,13 @@
   },
   "Notice": {
     "recruitmentNotice": "Wir suchen neue Mitglieder für das Herbstsemester 2026!",
+    "concertmaster": "Konzertmeister/-in",
     "strings": "Streicher",
     "stringsInstruments": "Violine, Bratsche, Kontrabass",
     "winds": "Holzbläser",
     "windsInstruments": "",
     "brass": "Blechbläser",
-    "brassInstruments": "Posaune",
+    "brassInstruments": "Bass- und Tenorposaune",
     "percussion": "Schlagzeug, Banjo",
     "learnMore": "Mehr erfahren",
     "joinUs": "Mehr über das Mitmachen"

--- a/messages/en.json
+++ b/messages/en.json
@@ -76,12 +76,13 @@
   },
   "Notice": {
     "recruitmentNotice": "We are recruiting new members for autumn 2026!",
+    "concertmaster": "Concert master",
     "strings": "Strings",
     "stringsInstruments": "Violin, Viola, Double bass",
     "winds": "Winds",
     "windsInstruments": "",
     "brass": "Brass",
-    "brassInstruments": "Trombone",
+    "brassInstruments": "Bass and tenor trombone",
     "percussion": "Percussion, Banjo",
     "learnMore": "Learn More",
     "joinUs": "Learn more about joining"

--- a/messages/en.json
+++ b/messages/en.json
@@ -45,6 +45,7 @@
   "Schedule": {
     "title": "Rehearsal Schedule",
     "subtitle": "Unless specifically indicated, rehearsals take place at Aki, Hirschengraben 86, 8001 Zürich",
+    "arrivalNote": "Please arrive by 18:00 to set up, warm up, and tune — rehearsals start at 18:15. Attendance at highlighted events is mandatory.",
     "date": "Date",
     "time": "Time",
     "location": "Location",

--- a/messages/en.json
+++ b/messages/en.json
@@ -76,7 +76,7 @@
   },
   "Notice": {
     "recruitmentNotice": "We are recruiting new members for autumn 2026!",
-    "concertmaster": "Concert master",
+    "concertmaster": "Concertmaster",
     "strings": "Strings",
     "stringsInstruments": "Violin, Viola, Double bass",
     "winds": "Winds",


### PR DESCRIPTION
## Summary
- Replace `content/schedule/rehearsals.json` with the HS26 program: rehearsals from 16 Sep to 18 Dec 2026 (Dvořák, Williams & Chaminade), two full-day Sunday sessions, a dress rehearsal, and concerts at Kirche Neumünster (17 Dec) and Grosser Saal des Konservatoriums Zürich (18 Dec)
- Restyle the section filter buttons as bordered pills with a solid-orange active state and a bolder label, so they read as clearly interactive

## Notes
- Rehearsals use the default Aki venue (hidden in UI); concerts use their named venues
- Dropped internal planning annotations ("(Chaos)", "machbar, wegen Logistik?") and assumed a 22:00 concert end time (only 19:30 starts were given)

## Test plan
- [ ] `pnpm dev` → `/probeplan` and `/en/schedule`: verify all entries render in the right order with correct sections
- [ ] Click each filter (All / Strings / Woodwinds / Brass) and confirm the list filters and the active pill is highlighted
- [ ] Download the ICS export and spot-check a couple of events

🤖 Generated with [Claude Code](https://claude.com/claude-code)