### PR TITLE
Add cellos to recruitment copy

### DIFF
--- a/app/[locale]/join/de.mdx
+++ b/app/[locale]/join/de.mdx
@@ -9,7 +9,7 @@ Wir freuen uns über Bewerbungen von Studierenden und Mitarbeitenden der ETH Zü
 Für das Herbstsemester 2026 suchen wir besonders:
 
 - **Konzertmeister/-in**
-- **Streicher**: Violine, Bratsche, Kontrabass
+- **Streicher**: Violine, Bratsche, Violoncello, Kontrabass
 - **Blechbläser**: Bass- und Tenorposaune
 
 Was du vorbereiten solltest, findest du im [Vorspielprozess](#audition-process) weiter unten.

--- a/app/[locale]/join/en.mdx
+++ b/app/[locale]/join/en.mdx
@@ -9,7 +9,7 @@ We welcome applications from students and staff of ETH Zürich and the Universit
 For autumn 2026 we are especially looking for:
 
 - **Concertmaster**
-- **Strings**: Violin, Viola, Double bass
+- **Strings**: Violin, Viola, Cello, Double bass
 - **Brass**: Bass and tenor trombone
 
 See the [audition process](#audition-process) below for what to prepare.

--- a/messages/de.json
+++ b/messages/de.json
@@ -81,7 +81,7 @@
     "recruitmentNotice": "Wir suchen neue Mitglieder für das Herbstsemester 2026!",
     "concertmaster": "Konzertmeister/-in",
     "strings": "Streicher",
-    "stringsInstruments": "Violine, Bratsche, Kontrabass",
+    "stringsInstruments": "Violine, Bratsche, Violoncello, Kontrabass",
     "winds": "Holzbläser",
     "windsInstruments": "",
     "brass": "Blechbläser",

--- a/messages/en.json
+++ b/messages/en.json
@@ -81,7 +81,7 @@
     "recruitmentNotice": "We are recruiting new members for autumn 2026!",
     "concertmaster": "Concertmaster",
     "strings": "Strings",
-    "stringsInstruments": "Violin, Viola, Double bass",
+    "stringsInstruments": "Violin, Viola, Cello, Double bass",
     "winds": "Winds",
     "windsInstruments": "",
     "brass": "Brass",


### PR DESCRIPTION
## What changed

Adds cellos to the strings recruitment list on the Join page and the site-wide recruitment notice, in German and English.

## Why

Polyphonia is also recruiting cello players for autumn 2026.

## Impact

Prospective cellists will see that their instrument is actively sought in both supported languages.

## Validation

- `pnpm lint`
- `git diff --check`
